### PR TITLE
fix: 使用 Cloudflare 反代 TG bot API 时推送失败

### DIFF
--- a/push/Telegram.py
+++ b/push/Telegram.py
@@ -16,7 +16,7 @@ def push(title, mdmsg, mdmsg_compat, textmsg, config):
         return
 
     url = 'https://api.telegram.org/bot' + config['botToken'] + '/sendMessage'
-    ret = requests.get(url, data={'chat_id': config['userId'], 'text': msg, 'parse_mode': "MarkdownV2"}, headers={
+    ret = requests.post(url, data={'chat_id': config['userId'], 'text': msg, 'parse_mode': "MarkdownV2"}, headers={
                   'Content-Type': 'application/x-www-form-urlencoded'})
     print('Telegram response: \n', ret.status_code)
     if ret.status_code != 200:


### PR DESCRIPTION
在进行带请求体的请求时，不能使用 GET 或者 HEAD 请求。Cloudflare Workers 的 request 拒绝发送这样的请求，所以要是把上面的 URL 替换成反代链接的话会无法正常工作。同时这样请求也是不规范的。所以希望能把 Telegram 推送改为 POST 请求。